### PR TITLE
Improve JSON log output ordering

### DIFF
--- a/src/main/java/com/logging/framework/appender/KafkaLoggingFileAppender.java
+++ b/src/main/java/com/logging/framework/appender/KafkaLoggingFileAppender.java
@@ -100,18 +100,19 @@ public class KafkaLoggingFileAppender {
             // Log the message with the appropriate level
             Level level = Level.toLevel(event.getLogLevel(), Level.INFO);
             
+            String logMsg = event.toJsonString();
             if (level == Level.ERROR) {
-                kafkaLogger.error(event.toLogString());
+                kafkaLogger.error(logMsg);
             } else if (level == Level.WARN) {
-                kafkaLogger.warn(event.toLogString());
+                kafkaLogger.warn(logMsg);
             } else if (level == Level.INFO) {
-                kafkaLogger.info(event.toLogString());
+                kafkaLogger.info(logMsg);
             } else if (level == Level.DEBUG) {
-                kafkaLogger.debug(event.toLogString());
+                kafkaLogger.debug(logMsg);
             } else if (level == Level.TRACE) {
-                kafkaLogger.trace(event.toLogString());
+                kafkaLogger.trace(logMsg);
             } else {
-                kafkaLogger.info(event.toLogString());
+                kafkaLogger.info(logMsg);
             }
         } finally {
             // Clear MDC values

--- a/src/main/java/com/logging/framework/model/LoggingEvent.java
+++ b/src/main/java/com/logging/framework/model/LoggingEvent.java
@@ -1,8 +1,11 @@
 package com.logging.framework.model;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Arrays;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * Model representing a logging event.
@@ -25,7 +28,7 @@ public class LoggingEvent {
     public LoggingEvent() {
         this.timestamp = LocalDateTime.now();
         this.status = MethodExecutionStatus.IN_PROGRESS;
-        this.additionalContext = new HashMap<>();
+        this.additionalContext = new LinkedHashMap<>();
     }
     
     /**
@@ -85,6 +88,45 @@ public class LoggingEvent {
         }
         
         return sb.toString();
+    }
+
+    /**
+     * Convert this logging event to a JSON string with a consistent field order.
+     *
+     * @return JSON representation of the event
+     */
+    public String toJsonString() {
+        Map<String, Object> jsonMap = new LinkedHashMap<>();
+        jsonMap.put("timestamp", timestamp.toString());
+        jsonMap.put("level", logLevel);
+        jsonMap.put("status", status);
+        jsonMap.put("class", className);
+        jsonMap.put("method", methodName);
+        if (executionTimeMs > 0) {
+            jsonMap.put("durationMs", executionTimeMs);
+        }
+        if (arguments != null && arguments.length > 0) {
+            jsonMap.put("arguments", Arrays.toString(arguments));
+        }
+        if (result != null) {
+            jsonMap.put("result", result);
+        }
+        if (kafkaMessageContext != null) {
+            jsonMap.put("kafka", kafkaMessageContext);
+        }
+        if (!additionalContext.isEmpty()) {
+            jsonMap.put("context", additionalContext);
+        }
+        if (exception != null) {
+            jsonMap.put("exception", exception.getClass().getSimpleName() + ": " + exception.getMessage());
+        }
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.writeValueAsString(jsonMap);
+        } catch (JsonProcessingException e) {
+            return jsonMap.toString();
+        }
     }
     
     // Getters and Setters


### PR DESCRIPTION
## Summary
- preserve insertion order when storing log context
- add `toJsonString()` to `LoggingEvent`
- log using JSON output in `KafkaLoggingFileAppender`

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684321d51ac48329936503deb34f6401